### PR TITLE
Add dockerized monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# server-analyser
+# Server Log Analyzer and Monitoring Suite
+
+This stack provides log collection, system monitoring, dashboards and alerting using Docker Compose.
+
+## Components
+- **syslog-ng** – receives system logs via TCP/UDP and forwards them to Loki
+- **Loki** – stores aggregated logs
+- **Prometheus** – scrapes metrics from exporters and evaluates alert rules
+- **Node Exporter** – exposes host metrics (CPU, memory, disk, etc.)
+- **cAdvisor** – collects container metrics
+- **Alertmanager** – handles alerts from Prometheus
+- **Grafana** – dashboards for logs and metrics
+
+## Usage
+1. Ensure Docker and Docker Compose are installed on the host.
+2. Clone this repository on the host machine with access to `/var/log`.
+3. Run `docker-compose up -d` from the repository root.
+4. Visit Grafana at [http://localhost:3000](http://localhost:3000) (default credentials `admin/admin`).
+5. Prometheus is available at [http://localhost:9090](http://localhost:9090).
+6. Logs are collected from `/var/log` on the host; view them in Grafana under *Explore* using the `Loki` datasource.
+
+## Checking Login Attempts
+- Navigate to Grafana > Explore and select the `Loki` datasource.
+- Query `{program="sshd"}` to see SSH login events including failures.
+- Failed login counts trigger the `ExcessiveLoginFailures` alert rule in Prometheus.
+
+## Adding Alert Rules
+- Edit `prometheus/alert.rules.yml` and add new rules under the `system-alerts` group.
+- Reload Prometheus configuration by restarting the Prometheus container: `docker-compose restart prometheus`.
+
+## Log Rotation
+Loki stores data on the `loki-data` volume. Adjust retention or set up periodic cleanup as required.
+
+## Network
+All services communicate on the `lognet` network defined in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,113 @@
+version: '3.8'
+services:
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki-data:/loki
+    networks:
+      - lognet
+
+  syslog-ng:
+    image: balabit/syslog-ng:latest
+    container_name: syslog-ng
+    ports:
+      - "514:514/udp"
+      - "601:601/tcp"
+    volumes:
+      - ./syslog-ng/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf:ro
+      - /var/log:/var/log:ro
+    depends_on:
+      - loki
+    networks:
+      - lognet
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    networks:
+      - lognet
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    pid: host
+    ports:
+      - "9100:9100"
+    volumes:
+      - /:/host:ro,rslave
+    command:
+      - '--path.rootfs=/host'
+    labels:
+      org.label-schema.group: "monitoring"
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9100'
+    networks:
+      - lognet
+    
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    ports:
+      - "8080:8080"
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - lognet
+    labels:
+      org.label-schema.group: "monitoring"
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '8080'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - lognet
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    ports:
+      - "9093:9093"
+    networks:
+      - lognet
+    volumes:
+      - alertmanager-data:/data
+
+volumes:
+  prometheus-data:
+  grafana-data:
+  alertmanager-data:
+  loki-data:
+
+networks:
+  lognet:
+    driver: bridge

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/dashboards/system_overview.json
+++ b/grafana/provisioning/dashboards/system_overview.json
@@ -1,0 +1,42 @@
+{
+  "id": null,
+  "uid": "system-overview",
+  "title": "System Overview",
+  "tags": ["system"],
+  "timezone": "browser",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "5s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "100 - (avg by(instance)(rate(node_cpu_seconds_total{mode='idle'}[1m])) * 100)", "legendFormat": "CPU"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100", "legendFormat": "Memory"}
+      ],
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "table",
+      "title": "Login Activity",
+      "datasource": "Loki",
+      "targets": [
+        {
+          "expr": "{program='sshd'} |= 'session opened'",
+          "format": "table"
+        }
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/prometheus/alert.rules.yml
+++ b/prometheus/alert.rules.yml
@@ -1,0 +1,39 @@
+ groups:
+ - name: system-alerts
+   rules:
+   - alert: HighCPUUsage
+     expr: 100 - (avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
+     for: 2m
+     labels:
+       severity: critical
+     annotations:
+       description: 'High CPU usage detected on {{ $labels.instance }}'
+       summary: 'CPU usage > 90%'
+
+   - alert: HighMemoryUsage
+     expr: node_memory_Active_bytes / node_memory_MemTotal_bytes * 100 > 85
+     for: 2m
+     labels:
+       severity: warning
+     annotations:
+       description: 'High memory usage detected on {{ $labels.instance }}'
+       summary: 'Memory usage > 85%'
+
+   - alert: HighDiskUsage
+     expr: node_filesystem_avail_bytes{fstype!="tmpfs",fstype!="overlay"} / node_filesystem_size_bytes{fstype!="tmpfs",fstype!="overlay"} * 100 < 20
+     for: 2m
+     labels:
+       severity: warning
+     annotations:
+       description: 'Disk space low on {{ $labels.instance }} mount {{ $labels.mountpoint }}'
+       summary: 'Disk usage > 80%'
+
+   - alert: ExcessiveLoginFailures
+     expr: increase(syslog_login_failed_total[5m]) > 5
+     for: 5m
+     labels:
+       severity: warning
+     annotations:
+       description: 'Multiple failed login attempts detected.'
+       summary: 'Failed logins > 5 in 5m'
+

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - alert.rules.yml
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+
+  - job_name: 'alertmanager'
+    static_configs:
+      - targets: ['alertmanager:9093']

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -1,0 +1,27 @@
+@version: 3.38
+@include "scl.conf"
+
+source s_local {
+    system();
+    internal();
+};
+
+source s_network {
+    tcp(port(601));
+    udp(port(514));
+};
+
+destination d_loki {
+    http(
+        url("http://loki:3100/loki/api/v1/push")
+        method("POST")
+        headers("Content-Type: application/json")
+        body-template("$(format-json --scope all-nv-pairs --rekey .* --key MESSAGE --add-prefix '.')")
+    );
+};
+
+log {
+    source(s_local);
+    source(s_network);
+    destination(d_loki);
+};


### PR DESCRIPTION
## Summary
- add Docker Compose stack with Loki, syslog-ng, Prometheus, node-exporter, cAdvisor, Grafana, and Alertmanager
- configure Prometheus scrape jobs and alert rules
- configure syslog-ng to forward logs to Loki
- provide Grafana provisioning
- document usage in README

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614aaa444c8333ad8a98b724171937