### PR TITLE
Add syslog-ng improvements and Grafana dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Server Log Analyzer and Monitoring Suite
 
-This stack provides log collection, system monitoring, dashboards and alerting using Docker Compose.
+This stack provides log aggregation, metrics monitoring and alerting using Docker Compose. Logs are forwarded via **syslog-ng** to **Loki** while metrics are scraped by **Prometheus** for display in **Grafana**.
 
 ## Components
 - **syslog-ng** – receives system logs via TCP/UDP and forwards them to Loki
@@ -17,7 +17,8 @@ This stack provides log collection, system monitoring, dashboards and alerting u
 3. Run `docker-compose up -d` from the repository root.
 4. Visit Grafana at [http://localhost:3000](http://localhost:3000) (default credentials `admin/admin`).
 5. Prometheus is available at [http://localhost:9090](http://localhost:9090).
-6. Logs are collected from `/var/log` on the host; view them in Grafana under *Explore* using the `Loki` datasource.
+6. Alertmanager can be reached at [http://localhost:9093](http://localhost:9093).
+7. Logs from `/var/log` and remote hosts are collected automatically. View them in Grafana under *Explore* using the `Loki` datasource to see real-time events.
 
 ## Checking Login Attempts
 - Navigate to Grafana > Explore and select the `Loki` datasource.
@@ -28,8 +29,21 @@ This stack provides log collection, system monitoring, dashboards and alerting u
 - Edit `prometheus/alert.rules.yml` and add new rules under the `system-alerts` group.
 - Reload Prometheus configuration by restarting the Prometheus container: `docker-compose restart prometheus`.
 
-## Log Rotation
-Loki stores data on the `loki-data` volume. Adjust retention or set up periodic cleanup as required.
+## Log Rotation & Retention
+Loki stores data on the `loki_data` volume. Adjust retention or set up periodic cleanup as required.
+
+If Grafana shows **"Log volume has not been configured"** or **"Traces not working"**, verify that the Loki data source is provisioned from `grafana/provisioning/datasources` and that the `loki_data` volume is mounted.
 
 ## Network
 All services communicate on the `lognet` network defined in `docker-compose.yml`.
+
+### Adding a New Log Source
+- Send logs via TCP or UDP port **514** to the host running syslog-ng.
+- Alternatively mount additional log files inside the syslog-ng container by editing `docker-compose.yml`.
+
+### Customising Alert Rules
+- Edit `prometheus/alert.rules.yml` and restart Prometheus with `docker-compose restart prometheus`.
+
+### Viewing Real-Time Logs
+- Open Grafana and navigate to **Explore**.
+- Choose the **Loki** data source and run queries such as `{program="sshd"}` to drill down into login activity.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
-      - loki-data:/loki
+      - loki_data:/loki
     networks:
       - lognet
 
@@ -16,7 +16,7 @@ services:
     container_name: syslog-ng
     ports:
       - "514:514/udp"
-      - "601:601/tcp"
+      - "514:514/tcp"
     volumes:
       - ./syslog-ng/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf:ro
       - /var/log:/var/log:ro
@@ -33,7 +33,7 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/alert.rules.yml:/etc/prometheus/alert.rules.yml:ro
-      - prometheus-data:/prometheus
+      - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     networks:
@@ -83,7 +83,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
     volumes:
-      - grafana-data:/var/lib/grafana
+      - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
@@ -100,13 +100,13 @@ services:
     networks:
       - lognet
     volumes:
-      - alertmanager-data:/data
+      - alertmanager_data:/data
 
 volumes:
-  prometheus-data:
-  grafana-data:
-  alertmanager-data:
-  loki-data:
+  prometheus_data:
+  grafana_data:
+  alertmanager_data:
+  loki_data:
 
 networks:
   lognet:

--- a/grafana/provisioning/dashboards/docker_metrics.json
+++ b/grafana/provisioning/dashboards/docker_metrics.json
@@ -1,0 +1,28 @@
+{
+  "id": null,
+  "uid": "docker-metrics",
+  "title": "Docker Metrics",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Container CPU",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "rate(container_cpu_usage_seconds_total{image!=""}[1m])", "legendFormat": "{{container}}"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "Container Memory",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "container_memory_usage_bytes{image!=""}", "legendFormat": "{{container}}"}
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/logs_by_service.json
+++ b/grafana/provisioning/dashboards/logs_by_service.json
@@ -1,0 +1,19 @@
+{
+  "id": null,
+  "uid": "logs-by-service",
+  "title": "Logs by Service",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Top Services",
+      "datasource": "Loki",
+      "targets": [
+        {"expr": "sum by(program)(rate({program!=""}[1m]))", "legendFormat": "{{program}}"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/ssh_login_events.json
+++ b/grafana/provisioning/dashboards/ssh_login_events.json
@@ -1,0 +1,28 @@
+{
+  "id": null,
+  "uid": "ssh-logins",
+  "title": "SSH Login Events",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "5s",
+  "panels": [
+    {
+      "type": "table",
+      "title": "Failed Logins",
+      "datasource": "Loki",
+      "targets": [
+        {"expr": "{program='sshd'} |= 'Failed password'", "format": "table"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 24, "h": 8}
+    },
+    {
+      "type": "table",
+      "title": "Successful Logins",
+      "datasource": "Loki",
+      "targets": [
+        {"expr": "{program='sshd'} |= 'Accepted password'", "format": "table"}
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/syslog-ng.conf
@@ -2,13 +2,14 @@
 @include "scl.conf"
 
 source s_local {
-    system();
+    file("/var/log/auth.log" follow-freq(1));
+    file("/var/log/syslog" follow-freq(1));
     internal();
 };
 
 source s_network {
-    tcp(port(601));
-    udp(port(514));
+    tcp(ip(0.0.0.0) port(514));
+    udp(ip(0.0.0.0) port(514));
 };
 
 destination d_loki {


### PR DESCRIPTION
## Summary
- use consistent underscored volume names
- expose syslog-ng on TCP 514
- parse auth.log and syslog in syslog-ng
- add dashboards for SSH logins, log volume, and container metrics
- update README with usage notes and troubleshooting tips

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617231af248333889f3be57fa8071b