### PR TITLE
Add alertmanager config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ All services communicate on the `lognet` network defined in `docker-compose.yml`
 ### Customising Alert Rules
 - Edit `prometheus/alert.rules.yml` and restart Prometheus with `docker-compose restart prometheus`.
 
+### Configuring Alert Receivers
+- Edit `alertmanager/alertmanager.yml` to add your email or Slack details under the `default` receiver.
+- Restart Alertmanager with `docker-compose restart alertmanager` for changes to take effect.
+
 ### Viewing Real-Time Logs
 - Open Grafana and navigate to **Explore**.
 - Choose the **Loki** data source and run queries such as `{program="sshd"}` to drill down into login activity.

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,0 +1,22 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+
+receivers:
+  - name: default
+    # Example email configuration
+    email_configs:
+      - to: your-team@example.com
+        from: alertmanager@example.com
+        smarthost: smtp.example.com:587
+        auth_username: smtp-user
+        auth_password: smtp-password
+    # Example Slack configuration
+    slack_configs:
+      - api_url: https://hooks.slack.com/services/EXAMPLE/EXAMPLE/EXAMPLE
+        channel: '#alerts'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
     networks:
       - lognet
     volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/data
 
 volumes:


### PR DESCRIPTION
## Summary
- add Alertmanager configuration file with example Slack/email receivers
- mount the new config in `docker-compose.yml`
- document how to customize alert receivers

## Testing
- `docker-compose` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686179419994833395355403743eaa34