### PR TITLE
Drop login failure alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This stack provides log aggregation, metrics monitoring and alerting using Docke
 ## Checking Login Attempts
 - Navigate to Grafana > Explore and select the `Loki` datasource.
 - Query `{program="sshd"}` to see SSH login events including failures.
-- Failed login counts trigger the `ExcessiveLoginFailures` alert rule in Prometheus.
 
 ## Adding Alert Rules
 - Edit `prometheus/alert.rules.yml` and add new rules under the `system-alerts` group.

--- a/prometheus/alert.rules.yml
+++ b/prometheus/alert.rules.yml
@@ -28,12 +28,4 @@
        description: 'Disk space low on {{ $labels.instance }} mount {{ $labels.mountpoint }}'
        summary: 'Disk usage > 80%'
 
-   - alert: ExcessiveLoginFailures
-     expr: increase(syslog_login_failed_total[5m]) > 5
-     for: 5m
-     labels:
-       severity: warning
-     annotations:
-       description: 'Multiple failed login attempts detected.'
-       summary: 'Failed logins > 5 in 5m'
 


### PR DESCRIPTION
## Summary
- remove unused `ExcessiveLoginFailures` alert rule
- trim login alert reference from README

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617d9bc7fc8333aa89fac52a778c9f