### PR TITLE
Pin Docker images to fixed versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ This stack provides log aggregation, metrics monitoring and alerting using Docke
 - **Alertmanager** – handles alerts from Prometheus
 - **Grafana** – dashboards for logs and metrics
 
+### Image Versions
+The `docker-compose.yml` file pins each service to a specific version:
+
+- `grafana/loki:2.9.0`
+- `balabit/syslog-ng:4.2.0`
+- `prom/prometheus:v2.46.0`
+- `prom/node-exporter:v1.7.0`
+- `gcr.io/cadvisor/cadvisor:v0.47.2`
+- `grafana/grafana:10.0.3`
+- `prom/alertmanager:v0.26.0`
+
 ## Usage
 1. Ensure Docker and Docker Compose are installed on the host.
 2. Clone this repository on the host machine with access to `/var/log`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - lognet
 
   syslog-ng:
-    image: balabit/syslog-ng:latest
+    image: balabit/syslog-ng:4.2.0
     container_name: syslog-ng
     ports:
       - "514:514/udp"
@@ -26,7 +26,7 @@ services:
       - lognet
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.46.0
     container_name: prometheus
     ports:
       - "9090:9090"
@@ -40,7 +40,7 @@ services:
       - lognet
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.7.0
     container_name: node-exporter
     pid: host
     ports:
@@ -57,7 +57,7 @@ services:
       - lognet
     
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.47.2
     container_name: cadvisor
     ports:
       - "8080:8080"
@@ -74,7 +74,7 @@ services:
       prometheus.io/port: '8080'
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.0.3
     container_name: grafana
     ports:
       - "3000:3000"
@@ -93,7 +93,7 @@ services:
       - lognet
 
   alertmanager:
-    image: prom/alertmanager:latest
+    image: prom/alertmanager:v0.26.0
     container_name: alertmanager
     ports:
       - "9093:9093"


### PR DESCRIPTION
## Summary
- pin image versions in `docker-compose.yml`
- list the selected versions in the README

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617e83b9008333980f41f5b67d19c0