### PR TITLE
Remove unnecessary monitoring ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `docker-compose.yml` file pins each service to a specific version:
 3. Run `docker-compose up -d` from the repository root.
 4. Visit Grafana at [http://localhost:3000](http://localhost:3000) (default credentials `admin/admin`).
 5. Prometheus is available at [http://localhost:9090](http://localhost:9090).
-6. Alertmanager can be reached at [http://localhost:9093](http://localhost:9093).
+6. Alertmanager runs on the internal `lognet` network. If you need to reach it remotely, publish port **9093** and allow it through your firewall.
 7. Logs from `/var/log` and remote hosts are collected automatically. View them in Grafana under *Explore* using the `Loki` datasource to see real-time events.
 
 ## Checking Login Attempts
@@ -46,6 +46,9 @@ If Grafana shows **"Log volume has not been configured"** or **"Traces not worki
 
 ## Network
 All services communicate on the `lognet` network defined in `docker-compose.yml`.
+Node Exporter, cAdvisor and Alertmanager are not exposed to the host by default.
+To reach them remotely, publish their ports (9100, 8080 and 9093) and open those
+ports in your firewall rules.
 
 ### Adding a New Log Source
 - Send logs via TCP or UDP port **514** to the host running syslog-ng.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,6 @@ services:
     image: prom/node-exporter:v1.7.0
     container_name: node-exporter
     pid: host
-    ports:
-      - "9100:9100"
     volumes:
       - /:/host:ro,rslave
     command:
@@ -59,8 +57,6 @@ services:
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.47.2
     container_name: cadvisor
-    ports:
-      - "8080:8080"
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -95,8 +91,6 @@ services:
   alertmanager:
     image: prom/alertmanager:v0.26.0
     container_name: alertmanager
-    ports:
-      - "9093:9093"
     networks:
       - lognet
     volumes:


### PR DESCRIPTION
## Summary
- drop host port mappings from node-exporter, cadvisor and alertmanager
- clarify how to reach alertmanager and exporters if required

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68617f40d728833382acd1afa47a6e16